### PR TITLE
results returns null

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/start.debug.sh
+++ b/start.debug.sh
@@ -2,7 +2,7 @@
 echo "API container loaded, waiting for rabbitmq"
 while ! nc -z message-queue 5672; do sleep 3; done
 echo "Rabbitmq loaded"
+npm install -g nodemon knex
 npm run postinstall
-npm install -g nodemon
 
 nodemon --debug=5858 index.js

--- a/worker.js
+++ b/worker.js
@@ -274,7 +274,7 @@ function Worker() {
           .join('userLanguages', 'users.id', 'userLanguages.userId')
           .join('languages', 'userLanguages.languageId', 'languages.id')
         }
-        return null;
+        return {};
       });
   };
 }


### PR DESCRIPTION
When no previous responses, getResults returning null was causing problems in the python worker, I believe due to the fact that null is false.

Now return empty JS object instead.